### PR TITLE
This is Kevin's fault

### DIFF
--- a/Epoch/GUI.py
+++ b/Epoch/GUI.py
@@ -98,7 +98,7 @@ class Generate_Multi(QWidget):
         for i in range(self.list_view.count()):
             numbers.append(self.list_view.item(i).text())
         clipboard = QApplication.clipboard()
-        clipboard.setText(','.join(numbers))
+        clipboard.setText('\n'.join(numbers))
 
 
 class Generate_Single(QWidget):


### PR DESCRIPTION
Modified the behavior of Multi ID Generation's Copy-to-clipboard function to delimit part numbers with a newline character for better behavior in spreadsheet applications.